### PR TITLE
app: dismiss an exited Pane with Enter or a click (Q22)

### DIFF
--- a/packages/app/src/commands/defaults.ts
+++ b/packages/app/src/commands/defaults.ts
@@ -125,18 +125,9 @@ export const COMMAND_DEFINITIONS: CommandDefinition[] = [
       const state = ctx.store.getState();
       const tab = tabFromArg(state, arg);
       if (!tab) return;
-      // The last Pane closing IS the Tab closing, confirmation included.
-      if (tab.surfaceIds.length <= 1) {
-        await closeTab(ctx, tab);
-        return;
-      }
       const pane = selectFocusedSurfaceId(state, tab.id);
       if (pane === null) return;
-      // Hand focus to the surviving sibling before the Pane goes, so the
-      // snapshot that removes it never lands on a Tab with stale focus.
-      const sibling = siblingLeaf(tab.layout, pane);
-      if (sibling !== null) ctx.store.dispatch({ type: 'pane.focus', tabId: tab.id, surfaceId: sibling });
-      await ctx.client.request('pane.close', { tab: tab.id, pane });
+      await closePane(ctx, tab, pane);
     },
   },
   {
@@ -342,6 +333,33 @@ async function closeTab(ctx: CommandContext, tab: TabView | null): Promise<void>
   }
   ctx.store.dispatch({ type: 'tab.confirmClose', tabId: null });
   await ctx.client.request('tab.close', { tab: tab.id });
+}
+
+/** Close one Pane of a Tab; closing the last Pane is closing the Tab. */
+export async function closePane(ctx: CommandContext, tab: TabView, pane: number): Promise<void> {
+  // The last Pane closing IS the Tab closing, confirmation included.
+  if (tab.surfaceIds.length <= 1) {
+    await closeTab(ctx, tab);
+    return;
+  }
+  // Hand focus to the surviving sibling before the Pane goes, so the
+  // snapshot that removes it never lands on a Tab with stale focus.
+  const sibling = siblingLeaf(tab.layout, pane);
+  if (sibling !== null) ctx.store.dispatch({ type: 'pane.focus', tabId: tab.id, surfaceId: sibling });
+  await ctx.client.request('pane.close', { tab: tab.id, pane });
+}
+
+/**
+ * Q22: an Exited Surface stays on screen, readable, until the user presses
+ * Enter or clicks it. This is that dismissal. A no-op while the Surface is
+ * still running, so a stray Enter on a live Pane never closes anything.
+ */
+export async function closeExitedPane(ctx: CommandContext, tabId: number, surfaceId: number): Promise<void> {
+  const state = ctx.store.getState();
+  const tab = state.tabs[tabId];
+  if (!tab || !tab.surfaceIds.includes(surfaceId)) return;
+  if (state.surfaces[surfaceId]?.status !== 'exited') return;
+  await closePane(ctx, tab, surfaceId);
 }
 
 /** Split the Tab's focused Pane; the new Pane takes focus once created. */

--- a/packages/app/src/commands/registry.test.ts
+++ b/packages/app/src/commands/registry.test.ts
@@ -3,6 +3,7 @@ import type { ReqParams, RequestType, WorkspaceSnapshot } from '@superterminal/p
 import { resolveBinding } from '../platform/keys.js';
 import type { WorkspaceState } from '../state/types.js';
 import { createWorkspaceStore, type WorkspaceStore } from '../state/workspace-store.js';
+import { closeExitedPane } from './defaults.js';
 import { buildRegistry, filterCommands, fuzzyScore, matchKeybinding } from './registry.js';
 import type { CommandContext, ControlClientLike, NativeBridge } from './types.js';
 import { noopNativeBridge } from './types.js';
@@ -273,6 +274,37 @@ describe('pane commands (ADR 0009)', () => {
     await registry.run('pane.close', ctx);
     expect(sent).toHaveLength(2);
     expect(store.getState().ui.confirmingCloseTabId).toBeNull();
+  });
+
+  test('closeExitedPane dismisses an Exited Pane and ignores a running one (Q22)', async () => {
+    const { ctx, sent, store } = harness({ split: true });
+    // Running: Enter/click on a live Pane must never close it.
+    await closeExitedPane(ctx, 10, 100);
+    expect(sent).toHaveLength(0);
+    store.applySnapshot({
+      ...splitSnapshot,
+      surfaces: splitSnapshot.surfaces.map((s) =>
+        s.id === 100 ? { ...s, state: { kind: 'exited' as const, code: 0, signal: null } } : s,
+      ),
+    });
+    await closeExitedPane(ctx, 10, 100);
+    expect(sent).toEqual([{ type: 'pane.close', params: { tab: 10, pane: 100 } }]);
+    expect(store.getState().ui.focusedPaneByTab[10]).toBe(102);
+    // A Surface that is not one of the Tab's Panes is ignored too.
+    await closeExitedPane(ctx, 11, 100);
+    expect(sent).toHaveLength(1);
+  });
+
+  test('closeExitedPane on the last Pane closes the Tab', async () => {
+    const { ctx, sent, store } = harness();
+    store.applySnapshot({
+      ...snapshot,
+      surfaces: snapshot.surfaces.map((s) =>
+        s.id === 100 ? { ...s, state: { kind: 'exited' as const, code: 130, signal: null } } : s,
+      ),
+    });
+    await closeExitedPane(ctx, 10, 100);
+    expect(sent).toEqual([{ type: 'tab.close', params: { tab: 10 } }]);
   });
 
   test('Close Tab confirms when ANY Pane has a foreground child', async () => {

--- a/packages/app/src/ui/SurfaceHost.tsx
+++ b/packages/app/src/ui/SurfaceHost.tsx
@@ -18,8 +18,9 @@
  * plane (Q43); this component never sees cell data at all (Q10, Q13).
  */
 
-import { useRef, useSyncExternalStore } from 'react';
+import { useMemo, useRef, useSyncExternalStore } from 'react';
 import type { Layout, SplitPath } from '@superterminal/protocol-ts';
+import { closeExitedPane } from '../commands/defaults.js';
 import {
   clampRatio,
   contentRect,
@@ -104,6 +105,7 @@ function PaneTree(props: PaneTreeProps) {
   if (node.kind === 'leaf') {
     return (
       <Pane
+        tabId={props.tabId}
         surfaceId={node.surface}
         focused={node.surface === props.focusedId}
         focusable={props.focusable}
@@ -200,12 +202,13 @@ function SplitDivider(props: {
 }
 
 function Pane(props: {
+  tabId: TabId;
   surfaceId: number;
   focused: boolean;
   focusable: boolean;
   onFocus: () => void;
 }) {
-  const { tokens, registry, config, store, commandBus, socketPath } = useServices();
+  const { tokens, registry, config, store, commandBus, commandContext, socketPath } = useServices();
   const command = useSyncExternalStore(
     commandBus.subscribe,
     commandBus.getSnapshot,
@@ -214,13 +217,46 @@ function Pane(props: {
   const theme: TerminalTheme = buildTerminalTheme(config.theme, config.terminal.boldIsBright);
   const fontZoom = useWorkspace((s) => s.ui.fontZoom);
   const id = props.surfaceId;
+  const tabId = props.tabId;
+  const exit = useWorkspace((s) => {
+    const surface = s.surfaces[id];
+    return surface?.status === 'exited' ? (surface.exitSignal ?? String(surface.exitCode ?? 0)) : null;
+  });
+  const exited = exit !== null;
+
+  // Q22: the grid stays readable after the program exits, and Enter or a
+  // click dismisses it. The grid consumes every key it can encode, Enter
+  // included, so once the Surface has exited we claim `enter` as a
+  // passthrough chord: the element declines it and GPUI bubbles it up to this
+  // wrapper's `onKeyDown` (HANDOVER V5). Nothing is listening on the PTY side
+  // any more, so no keystroke is lost by doing so.
+  const passthroughKeys = useMemo(
+    () => (exited ? [...registry.passthroughShortcuts, 'enter'] : registry.passthroughShortcuts),
+    [exited, registry],
+  );
+  const dismiss = () => {
+    void closeExitedPane(commandContext, tabId, id).catch((err: unknown) => {
+      store.dispatch({
+        type: 'toast.push',
+        text: `Could not close pane: ${err instanceof Error ? err.message : String(err)}`,
+        kind: 'error',
+      });
+    });
+  };
 
   return (
     <div
       testId={`pane-${id}`}
-      onMouseDown={props.onFocus}
+      onMouseDown={() => {
+        props.onFocus();
+        if (exited) dismiss();
+      }}
+      onKeyDown={(event: { key?: string }) => {
+        if (exited && event.key === 'enter') dismiss();
+      }}
       style={{
         display: 'flex',
+        flexDirection: 'column',
         flexGrow: 1,
         minWidth: 0,
         minHeight: 0,
@@ -231,6 +267,25 @@ function Pane(props: {
         backgroundColor: tokens.bg.glass,
       }}
     >
+      {exited ? (
+        <div
+          testId={`pane-${id}-exited`}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            flexShrink: 0,
+            paddingLeft: tokens.space.md,
+            paddingRight: tokens.space.md,
+            paddingTop: tokens.space.xs,
+            paddingBottom: tokens.space.xs,
+            backgroundColor: tokens.bg.glassSubtle,
+          }}
+        >
+          <text style={{ color: tokens.fg.muted, fontSize: tokens.font.chip }}>
+            {`Process exited (${exit}) — press Enter or click to close`}
+          </text>
+        </div>
+      ) : null}
       <terminal-grid
         // Remount on surface change so the element never carries stale state.
         key={id}
@@ -253,7 +308,7 @@ function Pane(props: {
         cursorBlink={config.terminal.cursorBlink}
         scrollbar={config.terminal.scrollbar}
         padding={{ top: 4, right: 8, bottom: 4, left: 8 }}
-        passthroughKeys={registry.passthroughShortcuts}
+        passthroughKeys={passthroughKeys}
         {...(command && command.surfaceId === id
           ? { command: { seq: command.seq, name: command.name, args: command.args } }
           : {})}


### PR DESCRIPTION
## Problem

Q22 (`docs/plan/00-grilling.md`) says an exited Surface stays on screen, readable, until the user presses Enter or clicks it. The first half works: the daemon marks the Surface exited and the tab strip shows the `⏻ code` badge. The second half was never wired up. `<terminal-grid>` consumes every keystroke it can encode, Enter included, and sends it to a PTY nobody is reading, so after `Ctrl+D` a Pane is simply stuck until the user finds `Alt+Shift+W` / `⇧⌘W` or the context menu. In practice exited Panes pile up inside splits (`st ls` on my box showed two `exited` Surfaces parked next to a live one).

## Fix

- `closePane(ctx, tab, pane)` is split out of the `pane.close` command and reused by a new `closeExitedPane(ctx, tabId, surfaceId)`. It is a no-op unless the Surface is exited **and** is one of the Tab's Panes, so a stray Enter on a live Pane can never close anything. The last Pane closing is still the Tab closing, confirmation and reseed included.
- Once the store says the Surface exited, `Pane` adds `enter` to the grid's `passthroughKeys`. The element declines it and GPUI bubbles it to the Pane wrapper's `onKeyDown`, the same HANDOVER V5 mechanism the app root already relies on for shortcuts. Nothing is listening on the PTY side any more, so no keystroke is lost. A mouse-down on the Pane dismisses it too.
- A one-line strip above the grid reads `Process exited (code) — press Enter or click to close`, so the behaviour is discoverable. `testId="pane-<id>-exited"` for automation.

No native changes; TypeScript only.

## Verification

- `bun test`: 296 pass. New cases cover running (ignored), exited in a split (closes, focuses sibling), a Surface not in the Tab (ignored), and last Pane (closes the Tab).
- `bun run typecheck` passes.
- Manually on Linux/X11 (Arch, i3, Intel Arc via Vulkan): opened a split, `Ctrl+D` in one Pane, the strip appears, Enter collapses the split; a click on another exited Pane does the same. `st ls` confirms the Surfaces are gone.

One thing I noticed while testing but did not touch: there is up to ~1 s between the shell exiting and the badge/strip appearing, which matches the once-a-second slow `reap` pass in `data/pump.rs` when the `exit_hint` fast path does not fire. Separate issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AotukeVm25zHjeA7MinKH
